### PR TITLE
More tests for Error Start Event

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/BPMNDirectDiagramMarshallerTest.java
@@ -58,6 +58,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.Assignme
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.DiagramSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.IsInterrupting;
+import org.kie.workbench.common.stunner.bpmn.definition.property.event.error.InterruptingErrorEventExecutionSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.message.MessageRef;
 import org.kie.workbench.common.stunner.bpmn.definition.property.event.signal.SignalRef;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
@@ -142,6 +143,7 @@ public class BPMNDirectDiagramMarshallerTest {
     private static final String BPMN_ENDTERMINATEEVENT = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/endTerminateEvent.bpmn";
     private static final String BPMN_PROCESSPROPERTIES = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/processProperties.bpmn";
     private static final String BPMN_BUSINESSRULETASKRULEFLOWGROUP = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/businessRuleTask.bpmn";
+    private static final String BPMN_EVENT_SUBPROCESS_STARTERROREVENT= "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/isInterruptingStartErrorEvent.bpmn";
     private static final String BPMN_REUSABLE_SUBPROCESS = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/reusableSubprocessCalledElement.bpmn";
     private static final String BPMN_EMBEDDED_SUBPROCESS = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/embeddedSubprocess.bpmn";
     private static final String BPMN_ADHOC_SUBPROCESS = "org/kie/workbench/common/stunner/bpmn/backend/service/diagram/adHocSubProcess.bpmn";
@@ -641,6 +643,51 @@ public class BPMNDirectDiagramMarshallerTest {
                      endNoneEvent.getGeneral().getName().getValue());
         assertEquals("MyEndNoneEventDocumentation",
                      endNoneEvent.getGeneral().getDocumentation().getValue());
+    }
+
+    @Test
+    @Ignore
+    public void testUnmarshallIsInterruptingStartErrorEvent() throws Exception {
+        Diagram<Graph, Metadata> diagram = unmarshall(BPMN_EVENT_SUBPROCESS_STARTERROREVENT);
+        assertDiagram(diagram,7);
+        assertEquals("EventSubprocessStartErrorEvent", diagram.getMetadata().getTitle());
+
+        // Check first start event with all FILLED properties
+        Node<? extends Definition, ?> startEventNode = diagram.getGraph().getNode("9ABD5C04-C6E2-4DF3-829F-ADB283330AD6");
+        StartErrorEvent startErrorEvent = (StartErrorEvent) startEventNode.getContent().getDefinition();
+        BPMNGeneralSet eventGeneralSet = startErrorEvent.getGeneral();
+        assertNotNull(eventGeneralSet);
+        assertEquals("StartErrorEvent", eventGeneralSet.getName().getValue());
+        assertEquals("Some not empty\nDocumentation\n~`!@#$%^&*()_+=-{}|[]\\:\";'<>/?.,",
+                     eventGeneralSet.getDocumentation().getValue());
+
+        InterruptingErrorEventExecutionSet eventExecutionSet = startErrorEvent.getExecutionSet();
+        assertNotNull(eventExecutionSet);
+        assertNotNull(eventExecutionSet.getErrorRef());
+        assertEquals("Error1", eventExecutionSet.getErrorRef().getValue());
+        assertEquals(true, eventExecutionSet.getIsInterrupting().getValue());
+
+        DataIOSet eventDataIOSet = startErrorEvent.getDataIOSet();
+        AssignmentsInfo assignmentsInfo = eventDataIOSet.getAssignmentsinfo();
+        assertEquals("||Var1:String||[dout]Var1->Var1", assignmentsInfo.getValue());
+
+        // Check second start event with all EMPTY properties
+        Node<? extends Definition, ?> emptyEventNode = diagram.getGraph().getNode("50B93E5E-C05D-40DD-BF48-2B6AE919763E");
+        StartErrorEvent emptyErrorEvent = (StartErrorEvent) emptyEventNode.getContent().getDefinition();
+        BPMNGeneralSet emptyEventGeneralSet = emptyErrorEvent.getGeneral();
+        assertNotNull(emptyEventGeneralSet);
+        assertEquals("", emptyEventGeneralSet.getName().getValue());
+        assertEquals("", emptyEventGeneralSet.getDocumentation().getValue());
+
+        InterruptingErrorEventExecutionSet emptyExecutionSet = emptyErrorEvent.getExecutionSet();
+        assertNotNull(emptyExecutionSet);
+        assertNotNull(emptyExecutionSet.getErrorRef());
+        assertEquals("", emptyExecutionSet.getErrorRef().getValue());
+        assertEquals(false, emptyExecutionSet.getIsInterrupting().getValue());
+
+        DataIOSet emptyDataIOSet = emptyErrorEvent.getDataIOSet();
+        AssignmentsInfo emptyAssignmentsInfo = emptyDataIOSet.getAssignmentsinfo();
+        assertEquals("", emptyAssignmentsInfo.getValue());
     }
 
     @Test

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/isInterruptingStartErrorEvent.bpmn
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/resources/org/kie/workbench/common/stunner/bpmn/backend/service/diagram/isInterruptingStartErrorEvent.bpmn
@@ -1,87 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_2ZoZoCIWEeiOCbRtqQSoQw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_Y1jkcCa7EeizcZRXanXWjw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_Var1Item" structureRef="String"/>
-  <bpmn2:error id="_d0652465-d793-3e0c-b2a4-d5dd02b2128e" errorCode="Error1" name="Error1"/>
+  <bpmn2:error id="_Y1jkfCa7EeizcZRXanXWjw"/>
+  <bpmn2:error id="Error1" errorCode="Error1"/>
   <bpmn2:process id="EventSubprocessStartErrorEvent" drools:packageName="org.jbpm" drools:version="1.0" name="EventSubprocessStartErrorEvent" isExecutable="true">
     <bpmn2:property id="Var1" itemSubjectRef="_Var1Item"/>
-    <bpmn2:subProcess id="_125AAEFB-C7EC-44DA-BBC7-E851DA69312F" drools:selectable="true" color:background-color="#ffffff" color:border-color="#000000" color:color="#000000" name="EventSubprocess" triggeredByEvent="true">
+    <bpmn2:subProcess id="5CEC35C6-5C0A-4BE0-81DB-86452BB4586B" name="EventSubprocess" triggeredByEvent="true">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
           <drools:metaValue><![CDATA[EventSubprocess]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
-      <bpmn2:ioSpecification id="_2ZpAsCIWEeiOCbRtqQSoQw">
-        <bpmn2:inputSet id="_2ZpAsSIWEeiOCbRtqQSoQw"/>
-        <bpmn2:outputSet id="_2ZpAsiIWEeiOCbRtqQSoQw"/>
+      <bpmn2:ioSpecification id="_Y1jkcSa7EeizcZRXanXWjw">
+        <bpmn2:inputSet id="_Y1jkcia7EeizcZRXanXWjw"/>
+        <bpmn2:outputSet id="_Y1jkcya7EeizcZRXanXWjw"/>
       </bpmn2:ioSpecification>
-      <bpmn2:startEvent id="_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="StartErrorEvent" isInterrupting="false">
+      <bpmn2:startEvent id="9ABD5C04-C6E2-4DF3-829F-ADB283330AD6" name="StartErrorEvent">
+        <bpmn2:documentation id="_Y1jkdCa7EeizcZRXanXWjw"><![CDATA[Some not empty
+Documentation
+~`!@#$%^&*()_+=-{}|[]\:";'<>/?.,]]></bpmn2:documentation>
         <bpmn2:extensionElements>
           <drools:metaData name="elementname">
             <drools:metaValue><![CDATA[StartErrorEvent]]></drools:metaValue>
           </drools:metaData>
         </bpmn2:extensionElements>
-        <bpmn2:outgoing>_192F1578-D3D5-4473-AE7C-57ACCFA81049</bpmn2:outgoing>
-        <bpmn2:dataOutput id="_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72_Var1" drools:dtype="String" name="Var1"/>
-        <bpmn2:dataOutputAssociation id="_2ZpAtCIWEeiOCbRtqQSoQw">
-          <bpmn2:sourceRef>_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72_Var1</bpmn2:sourceRef>
+        <bpmn2:outgoing>22F67142-F935-4918-9FD9-72BF02BD2CB5</bpmn2:outgoing>
+        <bpmn2:dataOutput id="9ABD5C04-C6E2-4DF3-829F-ADB283330AD6_Var1" drools:dtype="String" name="Var1"/>
+        <bpmn2:dataOutputAssociation id="_Y1jkdia7EeizcZRXanXWjw">
+          <bpmn2:sourceRef>9ABD5C04-C6E2-4DF3-829F-ADB283330AD6_Var1</bpmn2:sourceRef>
           <bpmn2:targetRef>Var1</bpmn2:targetRef>
         </bpmn2:dataOutputAssociation>
-        <bpmn2:outputSet id="_2ZpAsyIWEeiOCbRtqQSoQw">
-          <bpmn2:dataOutputRefs>_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72_Var1</bpmn2:dataOutputRefs>
+        <bpmn2:outputSet id="_Y1jkdSa7EeizcZRXanXWjw">
+          <bpmn2:dataOutputRefs>9ABD5C04-C6E2-4DF3-829F-ADB283330AD6_Var1</bpmn2:dataOutputRefs>
         </bpmn2:outputSet>
-        <bpmn2:errorEventDefinition id="_2ZpAtSIWEeiOCbRtqQSoQw" drools:erefname="Error1" errorRef="_d0652465-d793-3e0c-b2a4-d5dd02b2128e"/>
+        <bpmn2:errorEventDefinition id="_Y1jkdya7EeizcZRXanXWjw" drools:erefname="Error1" errorRef="Error1"/>
       </bpmn2:startEvent>
-      <bpmn2:endEvent id="_8DEA63F5-C922-4EAA-9883-671DAF2C73A6" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:endEvent id="9333FC52-FFE7-4F85-B205-5DCD9E972F84" name="">
         <bpmn2:extensionElements>
           <drools:metaData name="elementname">
             <drools:metaValue><![CDATA[]]></drools:metaValue>
           </drools:metaData>
         </bpmn2:extensionElements>
-        <bpmn2:incoming>_192F1578-D3D5-4473-AE7C-57ACCFA81049</bpmn2:incoming>
+        <bpmn2:incoming>22F67142-F935-4918-9FD9-72BF02BD2CB5</bpmn2:incoming>
       </bpmn2:endEvent>
-      <bpmn2:sequenceFlow id="_192F1578-D3D5-4473-AE7C-57ACCFA81049" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72" targetRef="_8DEA63F5-C922-4EAA-9883-671DAF2C73A6"/>
+      <bpmn2:sequenceFlow id="22F67142-F935-4918-9FD9-72BF02BD2CB5" sourceRef="9ABD5C04-C6E2-4DF3-829F-ADB283330AD6" targetRef="9333FC52-FFE7-4F85-B205-5DCD9E972F84"/>
+    </bpmn2:subProcess>
+    <bpmn2:subProcess id="761475D0-9A1B-4831-AB84-ED026011B04C" name="Event Sub-process" triggeredByEvent="true">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Event Sub-process]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:ioSpecification id="_Y1jkeCa7EeizcZRXanXWjw">
+        <bpmn2:inputSet id="_Y1jkeSa7EeizcZRXanXWjw"/>
+        <bpmn2:outputSet id="_Y1jkeia7EeizcZRXanXWjw"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:startEvent id="50B93E5E-C05D-40DD-BF48-2B6AE919763E" name="" isInterrupting="false">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:outgoing>433C5256-6596-42B2-A553-55BDA72784B0</bpmn2:outgoing>
+        <bpmn2:errorEventDefinition id="_Y1jkeya7EeizcZRXanXWjw" errorRef="_Y1jkfCa7EeizcZRXanXWjw"/>
+      </bpmn2:startEvent>
+      <bpmn2:endEvent id="DF3555A6-A090-4084-890A-4B93013D6BCB" name="">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>433C5256-6596-42B2-A553-55BDA72784B0</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:sequenceFlow id="433C5256-6596-42B2-A553-55BDA72784B0" sourceRef="50B93E5E-C05D-40DD-BF48-2B6AE919763E" targetRef="DF3555A6-A090-4084-890A-4B93013D6BCB"/>
     </bpmn2:subProcess>
   </bpmn2:process>
-  <bpmndi:BPMNDiagram id="_2ZpnwCIWEeiOCbRtqQSoQw">
-    <bpmndi:BPMNPlane id="_2ZpnwSIWEeiOCbRtqQSoQw" bpmnElement="EventSubprocessStartErrorEvent">
-      <bpmndi:BPMNShape id="_2ZpnwiIWEeiOCbRtqQSoQw" bpmnElement="_125AAEFB-C7EC-44DA-BBC7-E851DA69312F">
-        <dc:Bounds height="160.0" width="200.0" x="60.0" y="60.0"/>
+  <bpmndi:BPMNDiagram id="_Y1jkfSa7EeizcZRXanXWjw">
+    <bpmndi:BPMNPlane id="_Y1jkfia7EeizcZRXanXWjw" bpmnElement="EventSubprocessStartErrorEvent">
+      <bpmndi:BPMNShape id="_Y1jkfya7EeizcZRXanXWjw" bpmnElement="5CEC35C6-5C0A-4BE0-81DB-86452BB4586B">
+        <dc:Bounds height="113.0" width="281.0" x="46.0" y="48.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_2ZpnwyIWEeiOCbRtqQSoQw" bpmnElement="_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72">
-        <dc:Bounds height="30.0" width="30.0" x="90.0" y="125.0"/>
+      <bpmndi:BPMNShape id="_Y1jkgCa7EeizcZRXanXWjw" bpmnElement="9ABD5C04-C6E2-4DF3-829F-ADB283330AD6">
+        <dc:Bounds height="56.0" width="56.0" x="86.0" y="77.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_2ZpnxCIWEeiOCbRtqQSoQw" bpmnElement="_8DEA63F5-C922-4EAA-9883-671DAF2C73A6">
-        <dc:Bounds height="28.0" width="28.0" x="195.0" y="126.0"/>
+      <bpmndi:BPMNShape id="_Y1jkgSa7EeizcZRXanXWjw" bpmnElement="9333FC52-FFE7-4F85-B205-5DCD9E972F84">
+        <dc:Bounds height="56.0" width="56.0" x="222.0" y="77.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="_2ZpnxSIWEeiOCbRtqQSoQw" bpmnElement="_192F1578-D3D5-4473-AE7C-57ACCFA81049" sourceElement="_2ZpnwyIWEeiOCbRtqQSoQw" targetElement="_2ZpnxCIWEeiOCbRtqQSoQw">
-        <di:waypoint xsi:type="dc:Point" x="120.0" y="140.0"/>
-        <di:waypoint xsi:type="dc:Point" x="195.0" y="140.0"/>
+      <bpmndi:BPMNEdge id="_Y1jkgia7EeizcZRXanXWjw" bpmnElement="22F67142-F935-4918-9FD9-72BF02BD2CB5" sourceElement="_Y1jkgCa7EeizcZRXanXWjw" targetElement="_Y1jkgSa7EeizcZRXanXWjw">
+        <di:waypoint xsi:type="dc:Point" x="142.0" y="105.0"/>
+        <di:waypoint xsi:type="dc:Point" x="222.0" y="105.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_Y1jkgya7EeizcZRXanXWjw" bpmnElement="761475D0-9A1B-4831-AB84-ED026011B04C">
+        <dc:Bounds height="108.0" width="281.0" x="47.0" y="195.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Y1jkhCa7EeizcZRXanXWjw" bpmnElement="50B93E5E-C05D-40DD-BF48-2B6AE919763E">
+        <dc:Bounds height="56.0" width="56.0" x="87.0" y="222.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_Y1jkhSa7EeizcZRXanXWjw" bpmnElement="DF3555A6-A090-4084-890A-4B93013D6BCB">
+        <dc:Bounds height="56.0" width="56.0" x="223.0" y="222.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_Y1jkhia7EeizcZRXanXWjw" bpmnElement="433C5256-6596-42B2-A553-55BDA72784B0" sourceElement="_Y1jkhCa7EeizcZRXanXWjw" targetElement="_Y1jkhSa7EeizcZRXanXWjw">
+        <di:waypoint xsi:type="dc:Point" x="143.0" y="250.0"/>
+        <di:waypoint xsi:type="dc:Point" x="223.0" y="250.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
-  <bpmn2:relationship id="_2ZpnxiIWEeiOCbRtqQSoQw" type="BPSimData">
+  <bpmn2:relationship id="_Y1jkhya7EeizcZRXanXWjw" type="BPSimData">
     <bpmn2:extensionElements>
       <bpsim:BPSimData>
         <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
-          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_192F1578-D3D5-4473-AE7C-57ACCFA81049" id="_2ZqO0CIWEeiOCbRtqQSoQw">
-            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
-              <bpsim:Probability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="100.0"/>
-              </bpsim:Probability>
-            </bpsim:ControlParameters>
-          </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8DEA63F5-C922-4EAA-9883-671DAF2C73A6" id="_2ZqO0SIWEeiOCbRtqQSoQw">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="5CEC35C6-5C0A-4BE0-81DB-86452BB4586B" id="_Y1jkiCa7EeizcZRXanXWjw">
             <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
               <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:UniformDistribution max="10.0" min="5.0"/>
-              </bpsim:ProcessingTime>
-            </bpsim:TimeParameters>
-          </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_125AAEFB-C7EC-44DA-BBC7-E851DA69312F" id="_2ZqO0iIWEeiOCbRtqQSoQw">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
             <bpsim:CostParameters xsi:type="bpsim:CostParameters">
@@ -90,22 +122,36 @@
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9AAC784C-FEC9-49CA-A6F0-19D210C1BE72" id="_2Zq14CIWEeiOCbRtqQSoQw">
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="9ABD5C04-C6E2-4DF3-829F-ADB283330AD6" id="_Y1jkiSa7EeizcZRXanXWjw">
             <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
               <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
-            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
-              <bpsim:Probability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="100.0"/>
-              </bpsim:Probability>
-            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="50B93E5E-C05D-40DD-BF48-2B6AE919763E" id="_Y1jkiia7EeizcZRXanXWjw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="761475D0-9A1B-4831-AB84-ED026011B04C" id="_Y1jkiya7EeizcZRXanXWjw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
           </bpsim:ElementParameters>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_2ZoZoCIWEeiOCbRtqQSoQw</bpmn2:source>
-    <bpmn2:target>_2ZoZoCIWEeiOCbRtqQSoQw</bpmn2:target>
+    <bpmn2:source>_Y1jkcCa7EeizcZRXanXWjw</bpmn2:source>
+    <bpmn2:target>_Y1jkcCa7EeizcZRXanXWjw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>


### PR DESCRIPTION
Hi @alepintus,

sending you some extra tests, I guess some of them won't be valid due to issue we discussed, but some points will be still valid:

* test for documentation property
* test for new Marshaller (disabled for now due to incompatibility, so we will discuss it with others when it will be merged to your PR)
* refactored Object to XML marshaller (all similar tests will be refactored soon)

Possible points to remove (after discussion in JIRA issue)
* Second Event Subprocess with Error Start with FALSE value of `is interrupting` property (to update BPMN file, just import file to Workbench, remove subprocess with "empty" Start event and export file again)
* related to previous point tests, mostly second part of each tests.

But again, we need to discuss it first. I will update Jira with questions, and if we will decide to keep possibility to set FALSE value to `is interrupting` property, all suggestion will be valid without changes.

P.S. Sorry, for inconvenience about this task :)